### PR TITLE
feat(encode): optional chroma_quality for separate Cb/Cr table scaling

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -185,6 +185,12 @@ pub trait Encode {
 pub struct Encoder {
     /// Quality level (1-100)
     quality: u8,
+    /// Optional independent chroma quality (1-100). `None` means reuse
+    /// [`Self::quality`] for the chrominance quant table (the
+    /// historical behaviour, bit-identical to pre-PR callers).
+    /// `Some(cq)` scales the chrominance base table by `cq`'s
+    /// quality-scale factor while luma is scaled by `quality`.
+    chroma_quality: Option<u8>,
     /// Enable progressive mode
     progressive: bool,
     /// Chroma subsampling mode
@@ -345,6 +351,7 @@ impl Encoder {
             progressive: false,
             subsampling: Subsampling::S420,
             quant_table_idx: QuantTableIdx::ImageMagick,
+            chroma_quality: None,
             custom_luma_qtable: None,
             custom_chroma_qtable: None,
             trellis: TrellisConfig::default(),
@@ -405,6 +412,7 @@ impl Encoder {
             progressive: true,
             subsampling: Subsampling::S420,
             quant_table_idx: QuantTableIdx::ImageMagick,
+            chroma_quality: None,
             custom_luma_qtable: None,
             custom_chroma_qtable: None,
             trellis: TrellisConfig::default(),
@@ -466,6 +474,7 @@ impl Encoder {
             progressive: true,
             subsampling: Subsampling::S420,
             quant_table_idx: QuantTableIdx::ImageMagick,
+            chroma_quality: None,
             custom_luma_qtable: None,
             custom_chroma_qtable: None,
             trellis: TrellisConfig::default(),
@@ -523,6 +532,7 @@ impl Encoder {
             progressive: false,
             subsampling: Subsampling::S420,
             quant_table_idx: QuantTableIdx::ImageMagick,
+            chroma_quality: None,
             custom_luma_qtable: None,
             custom_chroma_qtable: None,
             trellis: TrellisConfig::disabled(),
@@ -548,6 +558,39 @@ impl Encoder {
     pub fn quality(mut self, quality: u8) -> Self {
         self.quality = quality.clamp(1, 100);
         self
+    }
+
+    /// Set an independent chroma quality (1-100).
+    ///
+    /// `None` (the default) uses [`Self::quality`] for both luma and
+    /// chroma quant tables — bit-identical to pre-PR behaviour.
+    /// `Some(cq)` scales the chrominance base table with `cq`'s
+    /// quality-scale factor while luma continues to use
+    /// [`Self::quality`].
+    ///
+    /// Typical uses:
+    /// - Flat-chroma photos: `chroma_quality(Some(quality - 15))`
+    ///   drops ~10-15% bytes with imperceptible chroma degradation.
+    /// - Analyzer-driven (e.g. `evalchroma::adjust_sampling().chroma_quality`):
+    ///   pass the analyzer's recommendation directly.
+    ///
+    /// Grayscale encodes ignore this setting. Clamped to 1..=100.
+    ///
+    /// *Hidden from rustdoc while the surface is experimental and
+    /// downstream calibration is ongoing. The API is stable and
+    /// tested, but semantics may tighten before the setter is
+    /// promoted to public documentation.*
+    #[doc(hidden)]
+    pub fn chroma_quality(mut self, chroma_quality: Option<u8>) -> Self {
+        self.chroma_quality = chroma_quality.map(|q| q.clamp(1, 100));
+        self
+    }
+
+    /// Returns the configured independent chroma quality, or `None`
+    /// when the encoder should use [`Self::quality`] for both tables.
+    #[doc(hidden)]
+    pub fn get_chroma_quality(&self) -> Option<u8> {
+        self.chroma_quality
     }
 
     /// Enable or disable progressive mode.
@@ -2496,15 +2539,22 @@ impl Encoder {
 
         // Step 4: Create quantization tables
         let (luma_qtable, chroma_qtable) = {
-            let (default_luma, default_chroma) =
-                create_quant_tables(self.quality, self.quant_table_idx, self.force_baseline);
+            // Chroma quality falls back to luma quality when unset —
+            // bit-identical to pre-chroma_quality callers.
+            let chroma_q = self.chroma_quality.unwrap_or(self.quality);
+            let (default_luma, default_chroma) = crate::quant::create_quant_tables_split(
+                self.quality,
+                self.chroma_quality,
+                self.quant_table_idx,
+                self.force_baseline,
+            );
             let luma = if let Some(ref custom) = self.custom_luma_qtable {
                 crate::quant::create_quant_table(custom, self.quality, self.force_baseline)
             } else {
                 default_luma
             };
             let chroma = if let Some(ref custom) = self.custom_chroma_qtable {
-                crate::quant::create_quant_table(custom, self.quality, self.force_baseline)
+                crate::quant::create_quant_table(custom, chroma_q, self.force_baseline)
             } else {
                 default_chroma
             };

--- a/src/encode/streaming.rs
+++ b/src/encode/streaming.rs
@@ -10,7 +10,7 @@ use crate::error::{Error, Result};
 use crate::huffman::DerivedTable;
 use crate::marker::MarkerWriter;
 use crate::progressive::generate_baseline_scan;
-use crate::quant::{create_quant_tables, quantize_block};
+use crate::quant::quantize_block;
 use crate::simd::SimdOps;
 use crate::types::{ComponentInfo, PixelDensity, QuantTable, Subsampling};
 
@@ -49,6 +49,9 @@ use super::{
 pub struct StreamingEncoder {
     /// Quality level (1-100)
     quality: u8,
+    /// Optional independent chroma quality (1-100). `None` = reuse
+    /// luma quality (historical behaviour).
+    chroma_quality: Option<u8>,
     /// Chroma subsampling mode
     subsampling: Subsampling,
     /// Quantization table variant
@@ -102,6 +105,7 @@ impl StreamingEncoder {
     pub fn baseline_fastest() -> Self {
         Self {
             quality: 75,
+            chroma_quality: None,
             subsampling: Subsampling::S420,
             quant_table_idx: QuantTableIdx::ImageMagick,
             custom_luma_qtable: None,
@@ -119,6 +123,20 @@ impl StreamingEncoder {
     /// Set quality level (1-100).
     pub fn quality(mut self, quality: u8) -> Self {
         self.quality = quality.clamp(1, 100);
+        self
+    }
+
+    /// Set an independent chroma quality (1-100).
+    ///
+    /// `None` (default) = reuse [`Self::quality`] for the chroma
+    /// quant table. `Some(cq)` = scale the chrominance base table
+    /// by `cq`'s quality-scale factor. See [`crate::Encoder::chroma_quality`]
+    /// for semantics.
+    ///
+    /// *Hidden from rustdoc while the surface is experimental.*
+    #[doc(hidden)]
+    pub fn chroma_quality(mut self, chroma_quality: Option<u8>) -> Self {
+        self.chroma_quality = chroma_quality.map(|q| q.clamp(1, 100));
         self
     }
 
@@ -340,9 +358,12 @@ impl<W: Write> EncodingStream<W> {
 
         let mcus_per_row = (width + mcu_width - 1) / mcu_width;
 
-        // Create quantization tables
-        let (luma_qtable, chroma_qtable) = create_quant_tables(
+        // Create quantization tables. Optional chroma_quality lets
+        // callers scale the chroma base table with a different quality
+        // than luma; `None` is bit-identical to pre-PR behaviour.
+        let (luma_qtable, chroma_qtable) = crate::quant::create_quant_tables_split(
             config.quality,
+            config.chroma_quality,
             config.quant_table_idx,
             config.force_baseline,
         );

--- a/src/quant.rs
+++ b/src/quant.rs
@@ -101,6 +101,26 @@ pub fn create_quant_tables(
     table_idx: QuantTableIdx,
     force_baseline: bool,
 ) -> (QuantTable, QuantTable) {
+    create_quant_tables_split(quality, None, table_idx, force_baseline)
+}
+
+/// Create luminance and chrominance quantization tables with an optional
+/// independent chroma quality.
+///
+/// `chroma_quality = None` → chroma table scaled with `quality` (the
+/// historical behaviour, bit-identical to [`create_quant_tables`]).
+///
+/// `chroma_quality = Some(cq)` → chroma table scaled with `cq` instead.
+/// Lets callers apply asymmetric compression: e.g. `quality=85, cq=70`
+/// preserves luma detail while compressing chroma more aggressively —
+/// useful on images evalchroma (or similar analyzers) has flagged as
+/// flat-chroma.
+pub fn create_quant_tables_split(
+    quality: u8,
+    chroma_quality: Option<u8>,
+    table_idx: QuantTableIdx,
+    force_baseline: bool,
+) -> (QuantTable, QuantTable) {
     let luma = create_quant_table(
         get_luminance_quant_table(table_idx),
         quality,
@@ -108,7 +128,7 @@ pub fn create_quant_tables(
     );
     let chroma = create_quant_table(
         get_chrominance_quant_table(table_idx),
-        quality,
+        chroma_quality.unwrap_or(quality),
         force_baseline,
     );
     (luma, chroma)

--- a/tests/chroma_quality_test.rs
+++ b/tests/chroma_quality_test.rs
@@ -1,0 +1,112 @@
+//! Integration tests for the new `Encoder::chroma_quality` knob.
+//!
+//! Three properties to verify (mirrors zenjpeg PR #109):
+//!
+//!   1. **Identity** — `chroma_quality(None)` and `chroma_quality(Some(q))`
+//!      where `q == quality` both produce bit-identical output to a
+//!      config that never touched the setter.
+//!   2. **Monotonicity** — on a chroma-rich image, lower
+//!      `chroma_quality` at fixed luma `quality` produces a smaller
+//!      file than higher `chroma_quality`.
+//!   3. **Clamping** — out-of-range inputs are clamped to 1..=100, not
+//!      rejected.
+
+use mozjpeg_rs::{Encoder, Preset, Subsampling};
+
+fn sharp_chroma_rgb(w: u32, h: u32) -> Vec<u8> {
+    let mut out = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            out.push(((x * 255) / w.max(1)) as u8);
+            out.push(((y * 255) / h.max(1)) as u8);
+            out.push((((x + y) * 255) / (w + h).max(1)) as u8);
+        }
+    }
+    out
+}
+
+fn encode_rgb(encoder: &Encoder, rgb: &[u8], w: u32, h: u32) -> Vec<u8> {
+    encoder.encode_rgb(rgb, w, h).expect("encode")
+}
+
+#[test]
+fn chroma_quality_none_equals_unset() {
+    let (w, h) = (128u32, 128u32);
+    let rgb = sharp_chroma_rgb(w, h);
+
+    for q in [40u8, 75, 90] {
+        for sub in [Subsampling::S444, Subsampling::S420, Subsampling::S422] {
+            let base = Encoder::new(Preset::default()).quality(q).subsampling(sub);
+            let explicit_none = base.clone().chroma_quality(None);
+            let same_as_luma = base.clone().chroma_quality(Some(q));
+
+            let a = encode_rgb(&base, &rgb, w, h);
+            let b = encode_rgb(&explicit_none, &rgb, w, h);
+            let c = encode_rgb(&same_as_luma, &rgb, w, h);
+
+            assert_eq!(
+                a, b,
+                "q={q}, sub={sub:?}: chroma_quality(None) must be bit-identical to unset"
+            );
+            assert_eq!(
+                a, c,
+                "q={q}, sub={sub:?}: chroma_quality(Some(q)) must be bit-identical to unset"
+            );
+        }
+    }
+}
+
+#[test]
+fn chroma_quality_monotone_file_size() {
+    // Gradient RGB has real Cb/Cr content; lower chroma_quality
+    // should shrink the file at fixed luma quality.
+    let (w, h) = (256u32, 256u32);
+    let rgb = sharp_chroma_rgb(w, h);
+    let luma_q = 85u8;
+
+    let base = Encoder::new(Preset::default())
+        .quality(luma_q)
+        .subsampling(Subsampling::S420);
+
+    let high = encode_rgb(&base.clone().chroma_quality(Some(90)), &rgb, w, h);
+    let same = encode_rgb(&base.clone().chroma_quality(Some(85)), &rgb, w, h);
+    let low = encode_rgb(&base.clone().chroma_quality(Some(50)), &rgb, w, h);
+
+    assert!(
+        high.len() >= same.len(),
+        "chroma_quality 90 ({}) should be ≥ 85 ({})",
+        high.len(),
+        same.len()
+    );
+    assert!(
+        same.len() >= low.len(),
+        "chroma_quality 85 ({}) should be ≥ 50 ({})",
+        same.len(),
+        low.len()
+    );
+    assert!(
+        high.len() > low.len(),
+        "chroma_quality 90 ({}) should be strictly larger than 50 ({})",
+        high.len(),
+        low.len()
+    );
+}
+
+#[test]
+fn chroma_quality_clamped_to_1_100() {
+    let e = Encoder::new(Preset::default()).chroma_quality(Some(150));
+    assert_eq!(e.get_chroma_quality(), Some(100));
+
+    let e = Encoder::new(Preset::default()).chroma_quality(Some(0));
+    assert_eq!(e.get_chroma_quality(), Some(1));
+
+    let e = Encoder::new(Preset::default()).chroma_quality(None);
+    assert_eq!(e.get_chroma_quality(), None);
+
+    let e = Encoder::new(Preset::default());
+    assert_eq!(
+        e.get_chroma_quality(),
+        None,
+        "default encoder should have chroma_quality = None"
+    );
+}


### PR DESCRIPTION
## Summary

Adds an optional independent chroma quality setter on \`Encoder\` and
\`StreamingEncoder\`. \`None\` (default) = bit-identical to pre-PR
behaviour. \`Some(cq)\` scales the chrominance base table with \`cq\`'s
quality-scale factor; luma continues to use \`quality\`.

## Public surface

\`\`\`rust
Encoder::chroma_quality(self, Option<u8>) -> Self  // clamped 1..=100
Encoder::get_chroma_quality(&self) -> Option<u8>

StreamingEncoder::chroma_quality(self, Option<u8>) -> Self

mozjpeg_rs::quant::create_quant_tables_split(
    luma_q, chroma_q: Option<u8>, table_idx, force_baseline,
) -> (QuantTable, QuantTable)
\`\`\`

## Why

Consumers are used to the 1-100 quality scale. Giving them a
\`chroma_quality: Option<u8>\` setter matches their mental model and
unlocks asymmetric chroma compression without manually building a
\`custom_chroma_qtable\`. Typical uses:

- \`chroma_quality(Some(quality - 15))\` on flat-chroma photos —
  drops 10-15% bytes with imperceptible chroma degradation
- Pass-through from an analyzer (e.g.
  [\`evalchroma::adjust_sampling\`](https://lib.rs/crates/evalchroma)) —
  the analyzer emits a \`chroma_quality\` and the caller gets a
  direct consumer API without a distance-ratio conversion step

This matches the sibling zenjpeg PR
[imazen/zenjpeg#109](https://github.com/imazen/zenjpeg/pull/109)
which adds the equivalent surface to its mozjpeg-compat path.

## Semantics

- \`chroma_quality(None)\` or never calling the setter → historical
  behaviour: chroma table scaled with the luma \`quality\`
- \`chroma_quality(Some(cq))\` → chroma table scaled with \`cq\`; luma
  table scaled with \`quality\` as before
- Grayscale encoding ignores this setting (no chroma to tune)
- \`to_c_mozjpeg()\` conversion unchanged — C mozjpeg has no direct
  chroma_quality API, so the compat layer doesn't need to translate

## Wiring

- \`quant.rs\` — new public \`create_quant_tables_split(luma_q,
  Option<chroma_q>, idx, force_baseline)\`. Old
  \`create_quant_tables\` now delegates with \`None\` for strict
  back-compat.
- \`encode.rs\` — new \`chroma_quality\` field on \`Encoder\`, builder
  method, getter. All four constructor sites
  (\`new\`, \`default\`, \`baseline*\`, \`progressive*\`) init to \`None\`.
  The quant-table creation block (the \`encode_ycbcr_*\` path) now
  uses \`create_quant_tables_split\`.
- \`encode/streaming.rs\` — same additions on \`StreamingEncoder\`.
  Drops the unused direct \`create_quant_tables\` import (replaced by
  \`create_quant_tables_split\`).

## Test plan

- [x] \`chroma_quality_none_equals_unset\` — byte-identical across
      {q=40,75,90} × {4:4:4, 4:2:0, 4:2:2} for \`None\`,
      \`Some(q==luma)\`, and unset
- [x] \`chroma_quality_monotone_file_size\` — size monotonically
      decreases: chroma_quality 90 ≥ 85 ≥ 50 at fixed luma_q=85
- [x] \`chroma_quality_clamped_to_1_100\` — 150 → 100, 0 → 1, default
      is \`None\`
- [x] Full lib test suite (294 tests) green