### PR TITLE
docs(readme): document the cancellation/timeout APIs (none were in the README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,40 @@ let crop_data = &full_image[crop_offset..];
 let jpeg = encoder.encode_rgb_strided(crop_data, crop_w, crop_h, full_stride)?;
 ```
 
+### Cancellation and timeout
+
+A long encode on untrusted input can be bounded two ways. The simplest is
+`*_cancellable`, which takes a `std::sync::atomic::AtomicBool` flag and an
+optional wall-clock timeout — no extra dependency:
+
+```rust
+use std::sync::atomic::AtomicBool;
+use std::time::Duration;
+
+let cancel = AtomicBool::new(false);
+// a watchdog/handler thread flips this on client disconnect:
+//   cancel.store(true, std::sync::atomic::Ordering::Relaxed);
+let jpeg = encoder.encode_rgb_cancellable(
+    &rgb, width, height,
+    Some(&cancel),                  // tripping the flag  -> Err(Error::Cancelled)
+    Some(Duration::from_secs(10)),  // exceeding the budget -> Err(Error::TimedOut)
+)?;
+```
+
+`*_cancellable` is provided for `encode_rgb_*` and `encode_gray_*`. For **RGBA**,
+or to share one cancellation token across several zen codecs, use the `*_with_stop`
+form — it takes any [`enough::Stop`](https://docs.rs/enough), and the simplest
+constructible token is `almost_enough::Stopper` (`cargo add almost-enough`),
+whose clones share one flag:
+
+```rust
+let stopper = almost_enough::Stopper::new();
+let watch = stopper.clone();   // hand a clone to a watchdog/deadline thread
+// std::thread::spawn(move || { /* on disconnect */ watch.cancel(); });
+let jpeg = encoder.encode_rgba_with_stop(&rgba, width, height, &stopper)?;
+// cancellation surfaces as Error::Cancelled (a deadline token yields Error::TimedOut).
+```
+
 ## Features
 
 - **Trellis quantization** - Rate-distortion optimized coefficient selection (AC + DC)


### PR DESCRIPTION
## What

Adds a **Cancellation and timeout** section to the README — there was none, despite the crate shipping two cancellation APIs.

## Why

An **insulated "external developer" test** — an agent given *only* `README.md` + `docs/public-api/mozjpeg-rs.txt`, no source — could not tell how to bound a long encode on untrusted input. The README had no cancellation section, so the agent had to guess between the two APIs it saw in the snapshot (`*_with_stop` vs `*_cancellable`), guess which error variant each produces, and (for `*_with_stop`) could not find a constructible `enough::Stop` token.

## The fix

- Document `*_cancellable(Option<&AtomicBool>, Option<Duration>)` as the dependency-free path: flag → `Error::Cancelled`, `Duration` budget → `Error::TimedOut`.
- Document `*_with_stop(&dyn enough::Stop)` for **RGBA** (there is no `encode_rgba_cancellable`) or to share one token across zen codecs, with the constructible `almost_enough::Stopper` (`cargo add almost-enough`).

## Verification

README-only; no API or behavior change. Verified against source:

| Symbol | Location |
|---|---|
| `encode_rgb_cancellable(.., Option<&AtomicBool>, Option<Duration>)` (wraps `_with_stop`) | `src/encode.rs:1642` |
| `encode_rgba_with_stop(.., &dyn enough::Stop)` (no `encode_rgba_cancellable`) | `src/encode.rs:1603` |
| `Error::Cancelled` / `Error::TimedOut` | `src/error.rs:61` / `63` |
| `StopReason::TimedOut → TimedOut`, else `Cancelled` | `src/error.rs:220` |
| `Stopper` (`new`/`cancel`, `Clone`, `impl Stop`) | `almost-enough-0.4.4` |

The README is not `include_str!`-compiled, so this is not a doctest — correctness rests on the source check above. Part of a cross-crate doc pass; the missing-constructible-token gap is universal across the zen codecs.
